### PR TITLE
Allow setting default class in config

### DIFF
--- a/lib/iconify.ex
+++ b/lib/iconify.ex
@@ -19,7 +19,7 @@ defmodule Iconify do
   end
 
   def prepare(assigns, mode \\ nil) do
-    assigns = Map.put_new(assigns, :class, Application.get_env(:iconify_ex, :default_class, nil))
+    assigns = Map.put_new_lazy(assigns, :class, fn -> Application.get_env(:iconify_ex, :default_class, "w-4 h-4") end)
 
     icon = Map.fetch!(assigns, :icon)
 

--- a/lib/iconify.ex
+++ b/lib/iconify.ex
@@ -19,6 +19,8 @@ defmodule Iconify do
   end
 
   def prepare(assigns, mode \\ nil) do
+    assigns = Map.put_new(assigns, :class, Application.get_env(:iconify_ex, :default_class, nil))
+
     icon = Map.fetch!(assigns, :icon)
 
     case mode || mode(emoji?(icon)) do


### PR DESCRIPTION
Hello!

Not passing a class prop `<.iconify icon="heroicons:academic-cap" />` currently fails with `key :class not found in: %{__changed__: nil, icon: "heroicons:academic-cap", icon_name: "heroicons:academic-cap"}`, so i thought I'd like to set a default class, and allow configuring it.

This PR applies to the function component only. The surface component currently defaults to "w-4 h-4", but maybe `nil` would be a better default and let the developer override it in config? If you're happy with this approach, let me know what you think the default `default_class` should be (nil or 'w-4 h-4') and I'll make the change to the surface component, and add something in the doco